### PR TITLE
Add fuzz test with a duplicate name

### DIFF
--- a/hclsyntax/fuzz/config/fuzz_test.go
+++ b/hclsyntax/fuzz/config/fuzz_test.go
@@ -18,3 +18,16 @@ func FuzzSyntaxParseConfig(f *testing.F) {
 		return
 	})
 }
+
+func FuzzSyntaxExpr(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		_, diags := hclsyntax.ParseConfig(data, "<fuzz-conf>", hcl.Pos{Line: 1, Column: 1})
+
+		if diags.HasErrors() {
+			return
+		}
+
+		return
+	})
+}
+


### PR DESCRIPTION
Adding a fuzz test with a duplicate name to test UI features when 2 functions share the same name (specifically FZBZ-1508).